### PR TITLE
file_manager: run command on file changes

### DIFF
--- a/_include/file_manager/init.sls
+++ b/_include/file_manager/init.sls
@@ -67,11 +67,23 @@ file_manager_{{ kind }}_{{ blockname }}_{{ extloop }}_{{ loop.index }}:
     - force: {{ item.get("force","") }}
     - clean: {{ item.get("clean","") }}
       {%- set a_loop = loop %}
-      {%- for cmd in item.get("apply", []) %}
+      {%- for apply in item.get("apply", []) %}
+        {%- if apply is not mapping %}
+          {%- set apply = {"cmd": apply} %}
+        {%- endif %}
+        {%- set cmd = apply["cmd"] %}
+        {%- set cwd = apply.get("cwd","") %}
+        {%- set runas = apply.get("runas",item.get(*user)) %}
+        {%- set only = apply.get("only","always") %}
 file_manager_{{ kind }}_apply_{{ blockname }}_{{ extloop }}_{{ a_loop.index }}_{{ loop.index }}:
   cmd.run:
     - name: {{ cmd.replace(*replace) }}
-    - runas: {{ item.get(*user) }}
+    - runas: {{ runas }}
+    - cwd: {{ cwd.replace(*replace) }}
+        {%- if only != "always" %}
+    - {{ only }}:
+      - file: {{ item["name"].replace(*replace) }}
+        {%- endif %}
       {%- endfor %}
     {%- endfor %}
   {%- endfor %}
@@ -120,20 +132,22 @@ file_manager_{{ kind }}_{{ blockname }}_{{ extloop }}_{{ loop.index }}:
       {% endif %}
       {%- set a_loop = loop %}
       {%- for apply in item.get("apply", []) %}
-        {%- if apply is mapping %}
-          {%- set cmd = apply["cmd"] %}
-          {%- set cwd = apply.get("cwd","") %}
-          {%- set runas = apply.get("runas",item.get(*user)) %}
-        {%- else %}
-          {%- set cmd = apply %}
-          {%- set cwd = "" %}
-          {%- set runas = item.get(*user) %}
+        {%- if apply is not mapping %}
+          {%- set apply = {"cmd": apply} %}
         {%- endif %}
+        {%- set cmd = apply["cmd"] %}
+        {%- set cwd = apply.get("cwd","") %}
+        {%- set runas = apply.get("runas",item.get(*user)) %}
+        {%- set only = apply.get("only","always") %}
 file_manager_{{ kind }}_apply_{{ blockname }}_{{ extloop }}_{{ a_loop.index }}_{{ loop.index }}:
   cmd.run:
     - name: {{ cmd.replace(*replace) }}
     - runas: {{ runas }}
     - cwd: {{ cwd.replace(*replace) }}
+        {%- if only != "always" %}
+    - {{ only }}:
+      - file: {{ item["name"].replace(*replace) }}
+        {%- endif %}
       {%- endfor %}
     {%- endfor %}
   {%- endfor %}

--- a/_include/file_manager/readme.md
+++ b/_include/file_manager/readme.md
@@ -33,6 +33,8 @@ The states are applied in the following order: recurse, directory, symlink, mana
           #   - cmd: /home/user/user.sh
           #     runas: user
           #     cwd: /home/user
+          #     only: onchanges # run command only if related directory is modified/created
+                                # `only` can be one of the https://docs.saltproject.io/en/latest/ref/states/requisites.html#requisites-types
              
 
           ## https://docs.saltproject.io/en/latest/ref/states/all/salt.states.file.html#salt.states.file.directory
@@ -68,6 +70,8 @@ The states are applied in the following order: recurse, directory, symlink, mana
           #   - cmd: /home/user/user.sh
           #     runas: user
           #     cwd: /home/user
+          #     only: onchanges # run command only if related file is modified/created
+                                # `only` can be one of the https://docs.saltproject.io/en/latest/ref/states/requisites.html#requisites-types
 
           ## https://docs.saltproject.io/en/latest/ref/states/all/salt.states.file.html#salt.states.file.managed
 


### PR DESCRIPTION
```
For example:

- run apply command before the target state will change (prereq)

files:
  directory:
    group1:
      - name: /opt/serv/test
        apply:
          - cmd: mkdir /opt/serv
            only: prereq
            runas: root

- run apply command only if the target state changes (onchanges)

files:
  managed:
    group1:
      - name: /etc/systemd/system/__APP_NAME__.service
        mode: 0644
        source: salt://app/host/__APP_NAME__/__APP_NAME__.service
        user: root
        group: root
        apply:
          - cmd: systemctl daemon-reload
            only: onchanges
```