### PR TITLE
Update vhost-gw.jinja

### DIFF
--- a/loki/nginx/vhost-gw.jinja
+++ b/loki/nginx/vhost-gw.jinja
@@ -121,11 +121,6 @@ server {
   ssl_certificate {{ server["ssl_cert"] }}; 
   ssl_certificate_key {{ server["ssl_key"] }};
   {%- endif %}
-  
-  {%- if "auth_basic" in loki_data["nginx"] %}
-  auth_basic "Administrator’s Area";
-  auth_basic_user_file {{ "/etc/nginx/htpasswd_" ~ loki_name }};
-  {%- endif %}
 
   proxy_connect_timeout       {{ loki_data["nginx"].get("timeout", 300) }};
   proxy_send_timeout          {{ loki_data["nginx"].get("timeout", 300) }};


### PR DESCRIPTION
loki: no auth_basic required on gateway's 3101 port