### PR TITLE
fix state error

### DIFF
--- a/acme/init.sls
+++ b/acme/init.sls
@@ -5,6 +5,11 @@ acme_dirs:
       - /opt/acme/cert
     - makedirs: True
 
+install_socat:
+  pkg.installed:
+   - names:
+     - socat
+
   {%- for acme_acc, acme_params in pillar["acme"].items() %}
 acme_acc_dirs_{{ loop.index }}:
   file.directory:


### PR DESCRIPTION
stderr:
 It is recommended to install socat first.
 We use socat for standalone server if you use standalone mode.
 If you don't use standalone mode, just ignore this warning.