### PR TITLE
victoriametrics: use = for arg k v spacing

### DIFF
--- a/victoriametrics/_setup.sls
+++ b/victoriametrics/_setup.sls
@@ -78,7 +78,7 @@
 
   {%- set vmargslist = [] %}
   {%- for k, v in vm_data.get("args", {}).items() %}
-    {%- do vmargslist.append("-" ~ k ~ " " ~ v) %}
+    {%- do vmargslist.append("-" ~ k ~ "=" ~ v) %}
   {%- endfor %}
 
   {%- if kind != "vmalert" %}


### PR DESCRIPTION
due to https://pkg.go.dev/flag#hdr-Command_line_flag_syntax