### PR TITLE
[mailcow_logs_viewer] implement formula

### DIFF
--- a/mailcow_logs_viewer/files/docker-compose.yml.jinja
+++ b/mailcow_logs_viewer/files/docker-compose.yml.jinja
@@ -1,0 +1,74 @@
+{#-
+  files/docker-compose.yml.jinja -> <base>/<id>/docker-compose.yml
+
+  Differs from the upstream compose file in three ways:
+    * name / container_name are unique - otherwise several stacks on the
+      same host fight over the same container names;
+    * the port is bound to 127.0.0.1 only, nginx does the exposing;
+    * the db service can be dropped (db_local: false) when PostgreSQL is
+      shared across instances.
+
+  ${...} below is Compose interpolation from the .env file in this same
+  directory, not Jinja. Salt leaves it untouched.
+-#}
+{%- set db_local = inst.get('db_local', True) %}
+# Managed by Salt (mailcow_logs_viewer). Manual edits will be overwritten.
+name: mlv-{{ id }}
+
+services:
+{%- if db_local %}
+  db:
+    image: {{ db_image }}
+    container_name: mlv-{{ id }}-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - mlv
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+{%- endif %}
+
+  app:
+    image: {{ image }}
+    container_name: mlv-{{ id }}-app
+    restart: unless-stopped
+{%- if db_local %}
+    depends_on:
+      db:
+        condition: service_healthy
+{%- endif %}
+    ports:
+      - "127.0.0.1:{{ inst.port }}:8080"
+    volumes:
+      - mailcowlogs_data:/app/data
+    networks:
+      - mlv
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+networks:
+  mlv:
+    driver: bridge
+
+volumes:
+{%- if db_local %}
+  postgres_data:
+    driver: local
+{%- endif %}
+  mailcowlogs_data:
+    driver: local
+

--- a/mailcow_logs_viewer/files/env.jinja
+++ b/mailcow_logs_viewer/files/env.jinja
@@ -1,0 +1,34 @@
+{#-
+  files/env.jinja -> <base>/<id>/.env
+
+  Merge order: builtin base -> pillar defaults -> per-instance env.
+  The last one wins. Because of this, new application variables never
+  require a change to the formula - just add them to the pillar.
+
+  Booleans are normalised to lowercase: a YAML boolean from the pillar
+  would otherwise land in the file as Python-style True/False.
+-#}
+{%- set env = {
+      'POSTGRES_HOST': 'db',
+      'POSTGRES_PORT': 5432,
+      'POSTGRES_USER': 'mailcowlogs',
+      'POSTGRES_DB': 'mailcowlogs',
+      'APP_TITLE': 'mailcow logs ' ~ id,
+      'COMPOSE_PROJECT_NAME': 'mlv-' ~ id,
+    } %}
+{%- do env.update(env_defaults) %}
+{%- do env.update(inst.get('env', {})) %}
+# Managed by Salt (mailcow_logs_viewer). Manual edits will be overwritten.
+# Instance: {{ id }}
+{% for k, v in env.items() | sort %}
+{%- if v is sameas true %}
+{{ k }}=true
+{%- elif v is sameas false %}
+{{ k }}=false
+{%- elif v is none %}
+{{ k }}=
+{%- else %}
+{{ k }}={{ v }}
+{%- endif %}
+{%- endfor %}
+

--- a/mailcow_logs_viewer/files/unit.service.jinja
+++ b/mailcow_logs_viewer/files/unit.service.jinja
@@ -1,0 +1,19 @@
+# Managed by Salt (mailcow_logs_viewer). Manual edits will be overwritten.
+[Unit]
+Description=mailcow Logs Viewer (%i)
+Documentation=https://github.com/ShlomiPorush/mailcow-logs-viewer
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory={{ base }}/%i
+ExecStart={{ compose }} up -d --remove-orphans
+ExecStop={{ compose }} down
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+

--- a/mailcow_logs_viewer/files/vhost.conf.jinja
+++ b/mailcow_logs_viewer/files/vhost.conf.jinja
@@ -1,0 +1,77 @@
+{#-
+  files/vhost.conf.jinja -> /etc/nginx/sites-enabled/<fqdn>.conf
+
+  have_cert is evaluated at state runtime, i.e. after issuance has run.
+  If issuance failed (DNS not propagated yet, provider API down) the site
+  comes up over plain HTTP instead of taking the whole nginx down on a
+  missing ssl_certificate.
+-#}
+{%- set have_cert = salt['file.file_exists'](tls.fullchain)
+                    and salt['file.file_exists'](tls.key) %}
+# Managed by Salt (mailcow_logs_viewer). Manual edits will be overwritten.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{ fqdn }};
+
+{%- if have_cert %}
+
+    return 301 https://$host$request_uri;
+{%- else %}
+
+    # No certificate yet - serve over plain HTTP for now.
+    location / {
+        proxy_pass http://127.0.0.1:{{ port }};
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+{%- endif %}
+}
+{%- if have_cert %}
+
+server {
+{%- if http2_on %}
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+{%- else %}
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+{%- endif %}
+    server_name {{ fqdn }};
+
+    ssl_certificate     {{ tls.fullchain }};
+    ssl_certificate_key {{ tls.key }};
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
+    # manual DMARC report uploads
+    client_max_body_size 32m;
+
+    access_log /var/log/nginx/{{ fqdn }}.access.log;
+    error_log  /var/log/nginx/{{ fqdn }}.error.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:{{ port }};
+        proxy_http_version 1.1;
+
+        # WebSocket for the Logs page
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+{%- endif %}
+

--- a/mailcow_logs_viewer/init.sls
+++ b/mailcow_logs_viewer/init.sls
@@ -1,0 +1,276 @@
+{#- mailcow_logs_viewer/init.sls
+
+  Deploys mailcow-logs-viewer: one isolated stack (app + PostgreSQL) per
+  mailcow server, all fronted by a single nginx with one wildcard
+  certificate issued through microdevops-formula/acme.
+
+  Host requirements: docker with the compose plugin, nginx.
+  Both are expected to be provided by other states.
+
+  NOTE. The verify_and_issue macro ends with a whitespace-stripping
+  endmacro tag, so its output carries no trailing newline. Therefore
+  right-stripping Jinja comments must NOT be used between YAML blocks
+  here: they would glue adjacent states onto one line. Everything below
+  uses plain YAML comments instead.
+-#}
+{%- from 'mailcow_logs_viewer/map.jinja' import
+      base, compose, image, db_image, instances, env_defaults,
+      manage_nginx, manage_ws_map, http2_on, ssl_params, security_opt, snhbs,
+      nginx_sls, nginx_pkg, nginx_req, remove_default_site,
+      acme_account, acme_app, acme_domain, acme_domains, acme_reload,
+      acme_state_id, acme_conf_glob, tls with context %}
+{%- if instances %}
+{%- from 'acme/macros.jinja' import verify_and_issue with context %}
+{%- if manage_nginx and nginx_sls %}
+
+include:
+  - {{ nginx_sls }}
+{%- endif %}
+
+################################################################
+# 1. Certificate
+################################################################
+# Issuance is idempotent: acme.sh returns exit code 2 when renewal is
+# not due yet, and the macro counts 2 as success.
+
+{{ verify_and_issue(acme_account, acme_app, acme_domains) }}
+
+# verify_and_issue.sh does not pass --reloadcmd, so after the nightly
+# renewal nginx would keep serving the old certificate from memory.
+# Store the reloadcmd in the domain conf separately; the cron job picks
+# it up from there. The unless is required because --install-cert fires
+# the reload command on every invocation.
+mlv-acme-reloadcmd:
+  cmd.run:
+    - shell: /bin/bash
+    - name: >-
+        /opt/acme/{{ acme_account }}/home/acme_local.sh --install-cert -d {{ acme_domain }}
+        --cert-file '{{ tls.cert }}'
+        --key-file '{{ tls.key }}'
+        --ca-file '{{ tls.ca }}'
+        --fullchain-file '{{ tls.fullchain }}'
+        --reloadcmd '{{ acme_reload }}'
+    - unless: grep -qs '^Le_ReloadCmd=' {{ acme_conf_glob }}
+    - require:
+      - cmd: {{ acme_state_id }}
+
+################################################################
+# 2. Shared scaffolding
+################################################################
+
+mlv-base-dir:
+  file.directory:
+    - name: {{ base }}
+    - user: root
+    - group: root
+    - mode: '0750'
+    - makedirs: True
+
+mlv-unit:
+  file.managed:
+    - name: /etc/systemd/system/mailcow-logs-viewer@.service
+    - source: salt://mailcow_logs_viewer/files/unit.service.jinja
+    - template: jinja
+    - mode: '0644'
+    - context:
+        base: {{ base }}
+        compose: {{ compose }}
+
+mlv-daemon-reload:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+      - file: mlv-unit
+{%- if manage_nginx %}
+
+{%- if not nginx_sls and nginx_pkg %}
+mlv-nginx-pkg:
+  pkg.installed:
+    - name: nginx
+{%- endif %}
+{%- if remove_default_site %}
+
+# The distro package ships a default_server vhost that answers every
+# unknown Host. microdevops-formula/nginx removes it as well, so this
+# state is a no-op when that formula is in play.
+mlv-nginx-default-site:
+  file.absent:
+    - name: /etc/nginx/sites-enabled/default
+{%- for k, v in nginx_req %}
+    - require:
+      - {{ k }}: {{ v }}
+{%- endfor %}
+    - onchanges_in:
+      - cmd: mlv-nginx-configtest
+{%- endif %}
+
+# microdevops-formula/nginx declares its own service.running for nginx
+# under the ID nginx_enable, but without reload: True. A second state on
+# the same service is harmless and is what carries the graceful reload on
+# config changes here.
+mlv-nginx-service:
+  service.running:
+    - name: nginx
+    - enable: True
+    - reload: True
+{%- for k, v in nginx_req %}
+    - require:
+      - {{ k }}: {{ v }}
+{%- endfor %}
+
+# Gate: no reload happens unless nginx -t passes first. A broken config
+# does not kill nginx on SIGHUP - the master silently rolls back to the
+# old one and keeps serving the old certificate, so without this check
+# the failure would be silent.
+mlv-nginx-configtest:
+  cmd.run:
+    - name: /usr/sbin/nginx -t
+{%- for k, v in nginx_req %}
+    - require:
+      - {{ k }}: {{ v }}
+{%- endfor %}
+    - require_in:
+      - service: mlv-nginx-service
+{%- if snhbs %}
+
+# Long viewer FQDNs overflow the default server_names_hash bucket and take
+# the whole nginx config down with them. See map.jinja for the arithmetic.
+mlv-nginx-server-names-hash:
+  file.managed:
+    - name: /etc/nginx/conf.d/server_names_hash.conf
+    - mode: '0644'
+    - makedirs: True
+{%- for k, v in nginx_req %}
+    - require:
+      - {{ k }}: {{ v }}
+{%- endfor %}
+    - contents: |
+        # Managed by Salt (mailcow_logs_viewer). Manual edits will be overwritten.
+        server_names_hash_bucket_size {{ snhbs }};
+    - onchanges_in:
+      - cmd: mlv-nginx-configtest
+    - watch_in:
+      - service: mlv-nginx-service
+{%- endif %}
+{%- if manage_ws_map %}
+
+# Required for the WebSocket stream on the Logs page. Set
+# manage_ws_map: false if this map is already declared by another
+# formula - a duplicate breaks nginx -t.
+mlv-nginx-ws-map:
+  file.managed:
+    - name: /etc/nginx/conf.d/websocket_upgrade.conf
+    - mode: '0644'
+    - makedirs: True
+{%- for k, v in nginx_req %}
+    - require:
+      - {{ k }}: {{ v }}
+{%- endfor %}
+    - contents: |
+        # Managed by Salt (mailcow_logs_viewer). Manual edits will be overwritten.
+        map $http_upgrade $connection_upgrade {
+            default upgrade;
+            ''      close;
+        }
+    - onchanges_in:
+      - cmd: mlv-nginx-configtest
+    - watch_in:
+      - service: mlv-nginx-service
+{%- endif %}
+{%- endif %}
+
+################################################################
+# 3. Instances
+################################################################
+{%- for id, inst in instances.items() %}
+
+mlv-dir-{{ id }}:
+  file.directory:
+    - name: {{ base }}/{{ id }}
+    - user: root
+    - group: root
+    - mode: '0750'
+    - require:
+      - file: mlv-base-dir
+
+mlv-env-{{ id }}:
+  file.managed:
+    - name: {{ base }}/{{ id }}/.env
+    - source: salt://mailcow_logs_viewer/files/env.jinja
+    - template: jinja
+    - mode: '0600'
+    - show_changes: False
+    - context:
+        id: {{ id }}
+        inst: {{ inst | tojson }}
+        env_defaults: {{ env_defaults | tojson }}
+    - require:
+      - file: mlv-dir-{{ id }}
+
+mlv-compose-{{ id }}:
+  file.managed:
+    - name: {{ base }}/{{ id }}/docker-compose.yml
+    - source: salt://mailcow_logs_viewer/files/docker-compose.yml.jinja
+    - template: jinja
+    - mode: '0640'
+    - context:
+        id: {{ id }}
+        inst: {{ inst | tojson }}
+        image: {{ image }}
+        db_image: {{ db_image }}
+        security_opt: {{ security_opt | tojson }}
+    - require:
+      - file: mlv-dir-{{ id }}
+
+# The unit owns boot persistence and the very first start.
+mlv-service-{{ id }}:
+  service.running:
+    - name: mailcow-logs-viewer@{{ id }}
+    - enable: True
+    - require:
+      - cmd: mlv-daemon-reload
+      - file: mlv-env-{{ id }}
+      - file: mlv-compose-{{ id }}
+
+# Changes to .env or docker-compose.yml are applied without a stop/start:
+# up -d recreates only what actually changed.
+mlv-apply-{{ id }}:
+  cmd.run:
+    - name: {{ compose }} up -d --remove-orphans
+    - cwd: {{ base }}/{{ id }}
+    - onchanges:
+      - file: mlv-env-{{ id }}
+      - file: mlv-compose-{{ id }}
+    - require:
+      - service: mlv-service-{{ id }}
+{%- if manage_nginx %}
+
+mlv-vhost-{{ id }}:
+  file.managed:
+    - name: /etc/nginx/sites-enabled/{{ inst.fqdn }}.conf
+    - source: salt://mailcow_logs_viewer/files/vhost.conf.jinja
+    - template: jinja
+    - mode: '0644'
+    - makedirs: True
+    - context:
+        fqdn: {{ inst.fqdn }}
+        port: {{ inst.port }}
+        http2_on: {{ http2_on }}
+        ssl_params: {{ ssl_params }}
+        tls: {{ tls | tojson }}
+    - require:
+{%- for k, v in nginx_req %}
+      - {{ k }}: {{ v }}
+{%- endfor %}
+      - cmd: mlv-acme-reloadcmd
+    - onchanges_in:
+      - cmd: mlv-nginx-configtest
+    - watch_in:
+      - service: mlv-nginx-service
+{%- endif %}
+{%- endfor %}
+{%- else %}
+
+# pillar mailcow_logs_viewer:instances is empty - nothing to do.
+{%- endif %}
+

--- a/mailcow_logs_viewer/map.jinja
+++ b/mailcow_logs_viewer/map.jinja
@@ -1,0 +1,123 @@
+{#-
+  mailcow_logs_viewer/map.jinja
+
+  The single place where derived values are computed. Imported by init.sls.
+  Nothing but {% set %} belongs here.
+-#}
+
+{%- set mlv = salt['pillar.get']('mailcow_logs_viewer', {}) %}
+
+{%- set base          = mlv.get('base_dir', '/opt/mailcow-logs-viewer') %}
+{%- set compose       = mlv.get('compose', '/usr/bin/docker compose') %}
+{%- set image         = mlv.get('image', 'ghcr.io/shlomiporush/mailcow-logs-viewer:latest') %}
+{%- set db_image      = mlv.get('db_image', 'postgres:15-alpine') %}
+{%- set instances     = mlv.get('instances', {}) %}
+{%- set env_defaults  = mlv.get('defaults', {}) %}
+
+{#- Extra --security-opt values for the containers. Normally empty.
+    Needed as a workaround for the runc masked-path regression: since
+    runc 1.4.3 (and 1.3.6) maskDir() mounts masked paths such as
+    /proc/acpi as tmpfs with nr_blocks=1,nr_inodes=1, which some kernels
+    reject with EINVAL, so no container can start at all. Setting
+    "systempaths=unconfined" leaves MaskedPaths empty and skips those
+    mounts. Fixed upstream in runc 1.4.4 - drop this once the host runs
+    that or newer. See opencontainers/runc#5348. -#}
+{%- set security_opt  = mlv.get('security_opt', []) %}
+{%- set manage_nginx  = mlv.get('manage_nginx', True) %}
+{%- set manage_ws_map = mlv.get('manage_ws_map', True) %}
+{%- set http2_on      = mlv.get('nginx_http2_on', False) %}
+
+{#- server_names_hash_bucket_size, written into conf.d.
+
+    nginx rejects a server_name when
+      sizeof(void*) + align(len + 2, sizeof(void*)) + sizeof(void*) > bucket_size
+    so at the common default of 64 any name longer than 46 characters fails
+    the whole config with "could not build server_names_hash". Viewer FQDNs
+    of the form <instance>.<viewer-domain> cross that line easily.
+
+    Skipped automatically when nginx.conf already declares the directive:
+    declaring it twice in the http context is a duplicate and breaks
+    nginx -t. Set to 0 to never manage it. -#}
+{%- set snhbs = mlv.get('server_names_hash_bucket_size', 128) %}
+{%- if snhbs and salt['file.search']('/etc/nginx/nginx.conf',
+                                     '^\\s*server_names_hash_bucket_size',
+                                     ignore_if_missing=True) %}
+{%-   set snhbs = 0 %}
+{%- endif %}
+
+{#- Two supported ways of getting nginx onto the host.
+
+    nginx_sls: depend on an external formula. For microdevops-formula the
+    value is 'nginx.nginx' and NOT 'nginx': nginx/init.sls only carries an
+    include and the actual states live in nginx/nginx.sls, while Salt
+    matches the sls requisite against __sls__ by exact string with no
+    globbing. Setting this also makes this formula include that SLS.
+
+    nginx_pkg: install the distro package from here and stay
+    self-contained. Used when nginx_sls is empty. -#}
+{%- set nginx_sls     = mlv.get('nginx_sls', '') %}
+{%- set nginx_pkg     = mlv.get('nginx_pkg', True) %}
+{%- set remove_default_site = mlv.get('remove_default_site', True) %}
+
+{#- Requisite entries that every state touching /etc/nginx must carry, as
+    (requisite_key, target) pairs. -#}
+{%- if nginx_sls %}
+{%-   set nginx_req = [('sls', nginx_sls)] %}
+{%- elif nginx_pkg %}
+{%-   set nginx_req = [('pkg', 'mlv-nginx-pkg')] %}
+{%- else %}
+{%-   set nginx_req = [] %}
+{%- endif %}
+
+{#- Optional snippet with shared TLS settings. microdevops-formula/nginx
+    writes /etc/nginx/snippets/ssl-params.conf (ciphers, dhparam, OCSP
+    stapling). When set, the vhost includes it and drops its own inline
+    ssl_protocols / ssl_session_* directives, which would otherwise be
+    duplicates in the same server context and break nginx -t. -#}
+{%- set ssl_params    = mlv.get('ssl_params_snippet', '') %}
+
+{#- --------------------------- ACME ---------------------------
+    Integration with microdevops-formula/acme. That formula does not
+    issue certificates by itself: it installs acme.sh per account and
+    drops the helper scripts. Issuance is done by the verify_and_issue
+    macro from acme/macros.jinja.
+-#}
+{%- set acme          = mlv.get('acme', {}) %}
+{%- set acme_account  = acme.get('account', '') %}
+{%- set acme_app      = acme.get('app', 'mlv') %}
+{%- set acme_domain   = acme.get('domain', '') %}
+{%- set acme_wildcard = acme.get('wildcard', True) %}
+{%- set acme_reload   = acme.get('reloadcmd',
+                                 '/usr/sbin/nginx -t && /usr/bin/systemctl reload nginx') %}
+
+{#- The bare domain MUST come first: verify_and_issue.sh takes $2 as part
+    of the certificate file name, so a wildcard in first position would put
+    a '*' into the file name. The wildcard itself is single-quoted so bash
+    does not glob-expand it while running the cmd.run state. -#}
+{%- if acme_wildcard %}
+{%-   set acme_domains = [acme_domain, "'*." ~ acme_domain ~ "'"] %}
+{%- else %}
+{%-   set acme_domains = [acme_domain] %}
+{%- endif %}
+
+{#- Exact replica of the state ID generated by acme/macros.jinja, so that
+    other states can point a require at it. -#}
+{%- set acme_state_id = '/opt/acme/home/' ~ acme_account ~ '/verify_and_issue.sh '
+                        ~ acme_app ~ ' ' ~ (acme_domains | join(' ') | md5) %}
+
+{#- Deployed certificate copies, the ones nginx reads.
+    Do NOT confuse with /opt/acme/<account>/cert, which is acme.sh's
+    internal --cert-home holding per-domain working dirs and their .conf. -#}
+{%- set cert_prefix = '/opt/acme/cert/' ~ acme_app ~ '_' ~ acme_domain %}
+{%- set tls = {
+      'cert':      cert_prefix ~ '_cert.cer',
+      'key':       cert_prefix ~ '_key.key',
+      'ca':        cert_prefix ~ '_ca.cer',
+      'fullchain': cert_prefix ~ '_fullchain.cer',
+    } %}
+
+{#- Glob over the domain conf. The '_ecc' suffix is covered because modern
+    acme.sh issues ECC certificates by default. -#}
+{%- set acme_conf_glob = '/opt/acme/' ~ acme_account ~ '/cert/'
+                         ~ acme_domain ~ '*/' ~ acme_domain ~ '.conf' %}
+

--- a/mailcow_logs_viewer/pillar.example
+++ b/mailcow_logs_viewer/pillar.example
@@ -1,0 +1,97 @@
+#!jinja|yaml
+#
+# Pillar for mailcow_logs_viewer.
+#
+# The shebang is mandatory: sdb URIs are resolved on the ops host while
+# the pillar is compiled, so the Vault token never travels to the target.
+#
+# Secrets must be hex/alphanumeric only (openssl rand -hex 32).
+# The characters @ : / ? # $ break either the PostgreSQL connection
+# string or .env parsing in Compose.
+
+################################################################
+# mailcow-logs-viewer
+################################################################
+mailcow_logs_viewer:
+
+  # Pin the tag. With 'latest', docker compose up will not pull a newer
+  # image once anything is present locally.
+  image: ghcr.io/shlomiporush/mailcow-logs-viewer:2.7.0
+  db_image: postgres:15-alpine
+
+  base_dir: /opt/mailcow-logs-viewer
+  compose: /usr/local/bin/docker-compose
+
+  manage_nginx: true        # false if vhosts are managed by another formula
+  manage_ws_map: true       # false if map $connection_upgrade is declared elsewhere
+  nginx_http2_on: false     # true only for nginx >= 1.25.1 (the "http2 on" directive)
+
+  acme:
+    account: example.com   # must match the key in the acme: pillar block above
+    app: mlv                # first part of the certificate file name
+    domain: logs.example.com
+    wildcard: true          # issue logs.example.com + *.logs.example.com
+    reloadcmd: "/usr/sbin/nginx -t && /usr/bin/systemctl reload nginx"
+    # -> /opt/acme/cert/mlv_logs.example.com_fullchain.cer
+    # -> /opt/acme/cert/mlv_logs.example.com_key.key
+
+  # ENV shared by all instances. Full variable reference lives in
+  # documentation/ENV_Settings.md in the application repository.
+  defaults:
+    TZ: Europe/Kyiv
+    LOG_LEVEL: WARNING
+
+    # Polling. The application defaults (20s / 1000 entries / all 10
+    # services) amount to roughly 8.6 GB/day of API traffic per instance,
+    # which is far too much for a centralised deployment over the public
+    # internet. The values below land around 170 MB/day.
+    FETCH_INTERVAL: 60
+    FETCH_COUNT_POSTFIX: 2000
+    RETENTION_DAYS: 7
+    RAW_LOGS_ENABLED: true
+    RAW_LOGS_FETCH_INTERVAL: 60
+    RAW_LOGS_FETCH_COUNT: 200
+    RAW_LOGS_SERVICES: postfix,rspamd-history,netfilter
+    RAW_LOGS_RETENTION_DAYS: 2
+
+    # Leave RSPAMD_URL empty so the app reaches Rspamd through
+    # MAILCOW_URL/rspamd. That is correct even when the viewer runs on a
+    # different server than mailcow.
+    RSPAMD_URL: ''
+
+    MAILCOW_API_VERIFY_SSL: true
+    SETTINGS_EDIT_VIA_UI_ENABLED: false   # config from Salt only, no drift via the UI
+    SUPPRESSION_ENABLED: false            # enable deliberately: it writes to Rspamd maps
+    BASIC_AUTH_ENABLED: false
+
+    OAUTH2_ENABLED: true
+    OAUTH2_PROVIDER_NAME: Authentik
+    OAUTH2_USE_OIDC_DISCOVERY: true
+    OAUTH2_ISSUER_URL: https://auth.example.com/application/o/mailcow-logs/
+
+  instances:
+
+    mailcow:
+      fqdn: mailcow.logs.example.com
+      port: 18101
+      # db_local: false     # skip the local PostgreSQL when the DB is shared
+      env:
+        MAILCOW_URL: https://mailcow.example.com
+        MAILCOW_API_KEY: 7F3541-866454-453F98-A12315-C12436
+        RSPAMD_PASSWORD: 55922243b41318a2541828479fe3f07f32145bcaae9e23643a4abf24daee084a
+        POSTGRES_PASSWORD: 5d36db6a62d9746bd1953fbfe940d671fe57de31e561824ee55dffcbf5fe1f33
+        SESSION_SECRET_KEY: 673bc30b887a57877272c275599cd6c65d1f19654770b4757afca2071f52b091
+        OAUTH2_CLIENT_ID: mailcow-logs-mailcow
+        OAUTH2_CLIENT_SECRET: 7a3269b70c4bac2bf6f246e9e2844ff71d2c1bb7f613248d64506345e8841e47
+        OAUTH2_REDIRECT_URI: https://mailcow.logs.example.com/api/auth/callback
+        # MAILCOW_API_KEY_RW is deliberately unset: without it the editing
+        # operations are disabled and the viewer stays strictly read-only.
+
+    # The remaining servers follow the same shape, ports 18102, 18103, ...
+    #
+    # example2:
+    #   fqdn: example2.logs.example.com
+    #   port: 18102
+    #   env:
+    #     MAILCOW_URL: https://mail.example2.com
+    #     ...


### PR DESCRIPTION
Deploys [mailcow-logs-viewer](https://github.com/shlomiporush/mailcow-logs-viewer): one isolated stack (app + PostgreSQL) per mailcow server, all fronted by a single nginx with one wildcard certificate issued through `acme`.

### Contents

- `init.sls` — certificate issuance, per-instance docker-compose stacks, systemd units, nginx vhosts
- `map.jinja` — pillar defaults and OS mapping
- `pillar.example` — full configuration reference
- `files/docker-compose.yml.jinja`, `files/env.jinja`, `files/unit.service.jinja`, `files/vhost.conf.jinja`

### Notes

- Multi-instance: each mailcow server gets its own app + DB stack on a dedicated port; `db_local: false` allows sharing an external PostgreSQL.
- Certificate renewal: `verify_and_issue.sh` does not pass `--reloadcmd`, so the formula stores it in the acme domain conf separately, otherwise nginx would keep serving the old certificate after the nightly renewal.
- Defaults are tuned down from the upstream application defaults (~8.6 GB/day of API traffic per instance) to roughly 170 MB/day, which is what a centralised deployment over the public internet can sustain.
- Read-only by default: `MAILCOW_API_KEY_RW` is left unset, `SETTINGS_EDIT_VIA_UI_ENABLED` and `SUPPRESSION_ENABLED` are off.
- `manage_nginx` / `manage_ws_map` / `nginx_http2_on` toggles let the formula coexist with other formulas managing nginx.
- Host requirements (docker with the compose plugin, nginx) are expected from other states.
